### PR TITLE
fix shebang for better portability

### DIFF
--- a/convert2composable.sh
+++ b/convert2composable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script to convert legacy templates into the new composable template format.
 # Actually, they only have one component - themselves, but have the new format


### PR DESCRIPTION
Use env(1) to locate shell binary
(@see http://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability), so it would work fine in FreeBSD and other systems with bash(1) binary placed not at /bin/bash, but at /usr/bin/bash, /usr/local/bin/bash or somewhere other.